### PR TITLE
Fix Kotlin plugin resolution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.9.25'
     repositories {
         google()
         mavenCentral()

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,6 +13,7 @@ pluginManagement {
     plugins {
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
         id "dev.flutter.flutter-plugin-loader" version "1.0.0" apply false
+        id "org.jetbrains.kotlin.android" version "1.9.25" apply false
     }
 }
 


### PR DESCRIPTION
## Summary
- specify the Kotlin Gradle plugin version for the settings plugin management

## Testing
- `git status --short`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68655f0086148320844c7df22288e51e