### PR TITLE
Fix Kotlin plugin ID for Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
+    // Updated plugin id to match settings.gradle
+    id "org.jetbrains.kotlin.android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 


### PR DESCRIPTION
## Summary
- update the Android `build.gradle` to use `org.jetbrains.kotlin.android`

## Testing
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686574a65e308320ab377d3ff9b77810