### PR TITLE
Fix Flutter lints compatibility

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -162,10 +162,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
+      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
 
 
-  flutter_lints: ^6.0.0
+  flutter_lints: ^5.0.0
 
   flutter_app_name: ^0.1.1
 flutter_app_name:


### PR DESCRIPTION
## Summary
- downgrade `flutter_lints` to `^5.0.0` so it works with Dart 3.5
- update lock file accordingly

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657503e3f08320b4cccd79fc55a4dc