### PR TITLE
Fix Android build by reverting Kotlin configuration

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "com.android.application"
-    // Updated plugin id to match settings.gradle
-    id "org.jetbrains.kotlin.android"
+    // Revert to stable Kotlin Android plugin
+    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.25'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -13,7 +13,7 @@ pluginManagement {
     plugins {
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
         id "dev.flutter.flutter-plugin-loader" version "1.0.0" apply false
-        id "org.jetbrains.kotlin.android" version "1.9.25" apply false
+        id "org.jetbrains.kotlin.android" version "1.9.10" apply false
     }
 }
 


### PR DESCRIPTION
## Summary
- revert Kotlin plugin id to `kotlin-android`
- set Kotlin version to `1.9.10`
- adjust settings.gradle to match plugin version
- use Gradle wrapper 8.0 for compatibility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686576a5c6f48320aceb55e58adca0f7