### PR TITLE
Fix service worker version deprecation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -34,7 +34,8 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var serviceWorkerVersion = null;
+    // Use the template token so the version is injected at build time.
+    var serviceWorkerVersion = '{{flutter_service_worker_version}}';
     var scriptLoaded = false;
     function loadMainDartJs() {
       if (scriptLoaded) {


### PR DESCRIPTION
## Summary
- update web/index.html to use the flutter_service_worker_version token

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657a2df5548320aebc5dd0d0582b98