### PR TITLE
Fix Windows artifact path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: windows-app
-          path: build/windows/runner/Release/**
+          path: build/windows/x64/runner/Release/**
 
       # Step 8: Build Android APK
       - name: Build Android APK


### PR DESCRIPTION
## Summary
- fix path to Windows release folder in CI workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686588ec305c8320945bae6619c8f437