### PR TITLE
Fix Android NDK version

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -8,7 +8,9 @@ plugins {
 android {
     namespace = "com.codingliquids.launch_pad_complete"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    // Pin NDK version to satisfy plugins audioplayers_android and
+    // path_provider_android which require NDK 27.0.12077973
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
## Summary
- explicitly set the Android NDK version required by audioplayers and path_provider plugins

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6866359b3a708320bc25e89af54abf2b